### PR TITLE
🐛 Ensure no empty news cards are displayed

### DIFF
--- a/src/News.tsx
+++ b/src/News.tsx
@@ -64,17 +64,20 @@ const News: React.FC = () => {
     <Grid container spacing={2} justify="center">
       {data &&
         data.map((d: NewsItemProps) => {
-          return (
-            <NewsItem
-              title={d.title}
-              byline={d.byline}
-              updated_date={d.updated_date}
-              abstract={d.abstract}
-              is90s={is90s}
-              url={d.url}
-              key={d.uri}
-            />
-          );
+          if (d.title) {
+            return (
+              <NewsItem
+                title={d.title}
+                byline={d.byline}
+                updated_date={d.updated_date}
+                abstract={d.abstract}
+                is90s={is90s}
+                url={d.url}
+                key={d.uri}
+              />
+            );
+          }
+          return null;
         })}
     </Grid>
   );


### PR DESCRIPTION
Sometimes, some seemingly blank cards with a timestamp are displayed.

<img width="411" alt="Screen Shot 2022-07-08 at 1 49 43 AM" src="https://user-images.githubusercontent.com/1740517/177926243-7d105dec-9ebb-44ef-aabb-7392f83d526b.png">

The REST API returns some entries without any content as we can see from the devtools.

<img width="823" alt="Screen Shot 2022-07-08 at 1 50 49 AM" src="https://user-images.githubusercontent.com/1740517/177926270-eb0fe413-f3ca-4efe-8f7b-2f9ae3e4bb66.png">

A workaround is to display the entries that has at least a title.